### PR TITLE
Add standalone server to deployment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "copyfiles": "^0.2.1",
     "faucet": "0.0.1",
+    "http-server": "^0.8.5",
     "live-reload": "^1.1.0",
     "opener": "^1.4.1",
     "parallelshell": "^2.0.0",
@@ -33,7 +34,7 @@
     "test": "test"
   },
   "scripts": {
-    "open": "opener http://localhost:63342/MemoryTyper/dist/index.html",
+    "open:dev": "opener http://localhost:9090",
     "pretest": "standard",
     "test": "tape test/**/*.js | faucet",
     "build:js": "browserify src/js/main.js -o dist/js/bundle.js",
@@ -41,9 +42,9 @@
     "build:static": "copyfiles --up 1 src/css/* src/index.html src/js/plugins.js dist",
     "watch:static": "watch \"npm run build:static\" src/",
     "build": "npm run build:static && npm run build:js",
-    "watch": "parallelshell \"npm run watch:static\" \"npm run watch:js\"",
+    "server": "http-server -p 9090 dist/",
     "livereload": "live-reload --port 9091 dist/",
-    "dev": "npm run open && parallelshell \"npm run livereload\" \"npm run watch\""
+    "dev": "npm run open:dev && parallelshell \"npm run server\" \"npm run livereload\" \"npm run watch:static\" \"npm run watch:js\""
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Was relying on WebStorm built-in server, which ain't that great anyway. Now using http-server.

Some minor updates to the scripts. Hopefully un-nested parallelshells will make the file watchers run faster
